### PR TITLE
Update Dockerfile with latest PCL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,7 @@ RUN wget -q -O- https://msbi.ipb-halle.de/~sneumann/file_databases.tgz | tar -C 
         wget -q https://zenodo.org/record/3520106/files/NPAtlas_Aug2019.csv; \
         wget -q https://zenodo.org/record/3548461/files/NORMANSusDat_20Nov2019.csv; \
         wget -q https://zenodo.org/record/3547718/files/COCONUT4MetFrag.csv; \
-        wget -q https://zenodo.org/record/3611238/files/PubChemLite_14Jan2020_tier0.csv; \
-        wget -q https://zenodo.org/record/3611238/files/PubChemLite_14Jan2020_tier1.csv; \
+        wget -q https://zenodo.org/record/4183801/files/PubChemLite_31Oct2020_exposomics.csv; \
         wget -q https://zenodo.org/record/4081057/files/PubChemLite_14Jan2020_tier1_CCSbase.csv; \
         wget -q https://zenodo.org/record/3957497/files/HBM4EU_CECscreen_MF_1Jul2020.csv; \
         wget -q https://zenodo.org/record/3957497/files/HBM4EU_CECscreen_MF_1Jul2020_plusTPs.csv; \


### PR DESCRIPTION
Removed PubChemLite tier0 and tier1 from Jan 2020, replaced with new 31 Oct "exposomics" version. Jan 2020 tier1 with CCS base remains.